### PR TITLE
Fix stash location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/bin/groovy
 
-def setupHoarder = """set org.romanowski.HoarderKeys.globalStashLocation in LocalRootProject := (baseDirectory in LocalRootProject).value / ".hoarder-stash" """
+def setupHoarder = """set org.romanowski.HoarderKeys.globalStashLocation in ThisBuild := (baseDirectory in LocalRootProject).value / ".hoarder-stash" """
 
 node {
 	def javaHome = tool 'jdk 1.8.0'

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note that `scalac` is not invoked in the "Test" stage:
 ```
 [info] Stash for pipeline-with-hoarder applied from /Users/jz/.jenkins/workspace/pipeline-with-hoarder/.hoarder-stash/pipeline-with-hoarder/HEAD/2.10 to List(/Users/jz/.jenkins/workspace/pipeline-with-hoarder/target/scala-2.10/classes, /Users/jz/.jenkins/workspace/pipeline-with-hoarder/target/scala-2.10/test-classes)
 
-[info] Stash for p1 applied from /Users/jz/.sbt/0.13/sbt-stash/pipeline-with-hoarder/HEAD/2.10 to List(/Users/jz/.jenkins/workspace/pipeline-with-hoarder/p1/target/scala-2.10/classes, /Users/jz/.jenkins/workspace/pipeline-with-hoarder/p1/target/scala-2.10/test-classes)
+[info] Stash for p1 applied from /Users/jz/.jenkins/workspace/pipeline-with-hoarder/.hoarder-stash/pipeline-with-hoarder/HEAD/2.10 to List(/Users/jz/.jenkins/workspace/pipeline-with-hoarder/p1/target/scala-2.10/classes, /Users/jz/.jenkins/workspace/pipeline-with-hoarder/p1/target/scala-2.10/test-classes)
 
 [info] Resolving org.scala-lang#scala-compiler;2.10.7 ...
 
@@ -21,7 +21,7 @@ Note that `scalac` is not invoked in the "Test" stage:
 
 [info] Done updating.
 
-[info] Stash for p2 applied from /Users/jz/.sbt/0.13/sbt-stash/pipeline-with-hoarder/HEAD/2.10 to List(/Users/jz/.jenkins/workspace/pipeline-with-hoarder/p2/target/scala-2.10/classes, /Users/jz/.jenkins/workspace/pipeline-with-hoarder/p2/target/scala-2.10/test-classes)
+[info] Stash for p2 applied from /Users/jz/.jenkins/workspace/pipeline-with-hoarder/.hoarder-stash/pipeline-with-hoarder/HEAD/2.10 to List(/Users/jz/.jenkins/workspace/pipeline-with-hoarder/p2/target/scala-2.10/classes, /Users/jz/.jenkins/workspace/pipeline-with-hoarder/p2/target/scala-2.10/test-classes)
 
 [success] Total time: 1 s, completed 12/02/2018 5:04:34 PM
 


### PR DESCRIPTION
I know it's quite unusual to see fixes to demo, but today is 2020 and the strangeness is common :)
In the demo the hoarder uses a ["global stash location"](https://github.com/romanowski/hoarder/blob/master/docs/stash.md#gobal-cache) for projects `p1` and `p2` (see the logs). For some person who accurately follows the guide (especially me), it'll be surprising for Jenkins with at least several workers. And actually stashing through the Jenkins not works as expected. 